### PR TITLE
fix pagination next issue

### DIFF
--- a/packages/app/src/app/page.tsx
+++ b/packages/app/src/app/page.tsx
@@ -79,7 +79,15 @@ export default async function Home({searchParams: {page, query}}: {searchParams:
                 <PaginationEllipsis />
               </PaginationItem> */}
               <PaginationItem>
-                <PaginationNext href="#" />
+                <PaginationNext
+                  href={
+                    pageNumber < Math.ceil(count / PAGE_LIMIT)
+                      ? `?page=${pageNumber + 1}${
+                          query ? `&query=${query}` : ""
+                        }`
+                      : "#"
+                  }
+                />
               </PaginationItem>
             </PaginationContent>
           </Pagination>


### PR DESCRIPTION
#### Summary
- Fixes the pagination issue when clicking next on the bottom of the page when hitting https://registry-dev.zkregex.com/
- Before this fix, clicking on the next button on the footer section does nothing. It redirects to https://registry-dev.zkregex.com/#
- Please verify if the frontend problem is solved on your end :)

#### Context
- Saw this message randomly https://t.me/zkemail/54/2593 Could not hesitate on fixing it