### PR TITLE
fix: throw error when regex does not match

### DIFF
--- a/packages/app/src/lib/code-gen/templates/zkemail_example/lib/generate_inputs.js.ejs
+++ b/packages/app/src/lib/code-gen/templates/zkemail_example/lib/generate_inputs.js.ejs
@@ -11,20 +11,22 @@ export async function generateCircuitInputs(rawEmail, inputs) {
     const emailBodyString = circuitInputs.emailBody ? Buffer.from(circuitInputs.emailBody.map(Number)).toString('ascii') : null;
     const emailHeaderString = circuitInputs.emailHeader ? Buffer.from(circuitInputs.emailHeader.map(Number)).toString('ascii') : null;
     let regexInputs = {};
-    let match;
     <% values.forEach(function(value) { %>
+    {
     <% if (value.location === "body") { %>
-    match = emailBodyString.match(new RegExp(<%- value.prefixRegex %>))
+        const match = emailBodyString.match(new RegExp(<%- value.prefixRegex %>))
     <% } else { %>
-    match = emailHeaderString.match(new RegExp(<%- value.prefixRegex %>))
+        const match = emailHeaderString.match(new RegExp(<%- value.prefixRegex %>))
     <% } %>
-    if (match) {
-        regexInputs = {
-            ...regexInputs,
-            <%- value.name %>RegexIdx: match.index + match[0].length
+        if (match) {
+            regexInputs = {
+                ...regexInputs,
+                <%- value.name %>RegexIdx: match.index + match[0].length
+            }
+        } else {
+            throw new Error(`Did not find a match for <%- value.name %> in the email sample`)
         }
     }
-    match = null;
     <% }) %>
 
     const packedInputs = {};


### PR DESCRIPTION
When uploading an email that does not include the matched regex, display an error.

<img width="538" alt="image" src="https://github.com/user-attachments/assets/79bbc5f2-02d4-4efb-963b-9e3f45f1fc2e">

Partially fixes: https://github.com/zkemail/zk-regex-registry/issues/5