### PR TITLE
fix: shaprecompute escaping

### DIFF
--- a/packages/app/src/lib/code-gen/templates/zkemail_example/lib/generate_inputs.js.ejs
+++ b/packages/app/src/lib/code-gen/templates/zkemail_example/lib/generate_inputs.js.ejs
@@ -5,7 +5,7 @@ export async function generateCircuitInputs(rawEmail, inputs) {
         ignoreBodyHashCheck: <%- ignoreBodyHashCheck %>,
         maxBodyLength: <%- ignoreBodyHashCheck ? 0 : emailBodyMaxLength %>,
         maxHeaderLength: 1024,
-        shaPrecomputeSelector: "<%- shaPrecomputeSelector %>",
+        shaPrecomputeSelector: "<%- shaPrecomputeSelector.replaceAll('"', '\\\"') %>",
     });
 
     const emailBodyString = circuitInputs.emailBody ? Buffer.from(circuitInputs.emailBody.map(Number)).toString('ascii') : null;


### PR DESCRIPTION
https://github.com/zkemail/zk-regex-registry/issues/5